### PR TITLE
회원 로그인 및 회원 정보 수정 구현 #6

### DIFF
--- a/src/main/java/Backend/FinalProject/controller/MemberController.java
+++ b/src/main/java/Backend/FinalProject/controller/MemberController.java
@@ -2,14 +2,16 @@ package Backend.FinalProject.controller;
 
 import Backend.FinalProject.domain.Member;
 import Backend.FinalProject.dto.ResponseDto;
+import Backend.FinalProject.dto.request.LoginRequestDto;
+import Backend.FinalProject.dto.request.MemberEditRequestDto;
 import Backend.FinalProject.dto.request.SignupRequestDto;
 import Backend.FinalProject.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 
 @RestController
@@ -18,10 +20,38 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    /**
+     * 회원가입
+     *
+     * @param request : 회원가입에 필요한 정보들을 담은 Dto
+     * @param imgFile : 회원가입시 이미지 파일 업로드
+     */
     @PostMapping("/member/signup")
-    public ResponseDto<?> signup(
+    public ResponseDto<String> signup(
             @RequestPart SignupRequestDto request,
             @RequestPart MultipartFile imgFile) {
         return memberService.createMember(request, imgFile);
+    }
+
+    /**
+     * 로그인
+     *
+     * @param loginRequestDto : 로그인에 필요한 정보들을 담은 Dto
+     * @param response        : Header에 Token을 담아주는 역할
+     */
+    @PostMapping("/member/login")
+    public ResponseDto<String> login(
+            @RequestBody LoginRequestDto loginRequestDto,
+            HttpServletResponse response) {
+        return memberService.login(loginRequestDto, response);
+    }
+
+    @PutMapping("/member")
+    public ResponseDto<?> editProfile(
+            @RequestPart MemberEditRequestDto request,
+            @RequestPart(required = false) MultipartFile imgFile,
+            HttpServletRequest httpServletRequest
+    ) {
+        return memberService.updateMember(request, imgFile, httpServletRequest);
     }
 }

--- a/src/main/java/Backend/FinalProject/domain/ImageFile.java
+++ b/src/main/java/Backend/FinalProject/domain/ImageFile.java
@@ -5,10 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -21,6 +18,7 @@ public class ImageFile {
     private Long id;
 
     private String imageName;
+    @Column(length = 1000)
     private String url;
 
 }

--- a/src/main/java/Backend/FinalProject/domain/Member.java
+++ b/src/main/java/Backend/FinalProject/domain/Member.java
@@ -29,11 +29,22 @@ public class Member {
     @Column(unique = true)
     private String nickname;
 
-    private String img_url;
+    @Column(length = 1000)
+    private String imgUrl;
 
     @Enumerated(value = EnumType.STRING)
     private Authority userRole;
 
 
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateImage(String imgUrl) {
+        this.imgUrl = imgUrl;
+    }
 }

--- a/src/main/java/Backend/FinalProject/dto/ResponseDto.java
+++ b/src/main/java/Backend/FinalProject/dto/ResponseDto.java
@@ -8,13 +8,14 @@ import lombok.Getter;
 public class ResponseDto<T> {
     private boolean success;
     private T data;
+    private Error error;
 
     public static <T> ResponseDto<T> success(T data) {
-        return new ResponseDto<>(true, data);
+        return new ResponseDto<>(true, data, null);
     }
 
-    public static <T> ResponseDto<T> fail(T data) {
-        return new ResponseDto<>(false, data);
+    public static <T> ResponseDto<T> fail(String code, String message) {
+        return new ResponseDto<>(false, null,  new Error(code, message) );
     }
 
     @Getter

--- a/src/main/java/Backend/FinalProject/dto/request/LoginRequestDto.java
+++ b/src/main/java/Backend/FinalProject/dto/request/LoginRequestDto.java
@@ -1,0 +1,9 @@
+package Backend.FinalProject.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+    private String userId;
+    private String password;
+}

--- a/src/main/java/Backend/FinalProject/dto/request/MemberEditRequestDto.java
+++ b/src/main/java/Backend/FinalProject/dto/request/MemberEditRequestDto.java
@@ -1,0 +1,9 @@
+package Backend.FinalProject.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class MemberEditRequestDto {
+    private String password;
+    private String nickname;
+}

--- a/src/main/java/Backend/FinalProject/sercurity/AccessDeniedHandlerException.java
+++ b/src/main/java/Backend/FinalProject/sercurity/AccessDeniedHandlerException.java
@@ -19,7 +19,7 @@ public class AccessDeniedHandlerException implements AccessDeniedHandler {
         response.setContentType("application/json;charset=UTF-8");
         response.getWriter().println(
                 new ObjectMapper().writeValueAsString(
-                        ResponseDto.fail("접근거부: 로그인이 필요합니다!")
+                        ResponseDto.fail("ACCESS DENIED","접근거부: 로그인이 필요합니다!")
                 )
         );
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);

--- a/src/main/java/Backend/FinalProject/sercurity/AuthenticationEntryPointException.java
+++ b/src/main/java/Backend/FinalProject/sercurity/AuthenticationEntryPointException.java
@@ -20,7 +20,7 @@ public class AuthenticationEntryPointException implements
         response.setContentType("application/json;charset=UTF-8");
         response.getWriter().println(
                 new ObjectMapper().writeValueAsString(
-                        ResponseDto.fail("인증실패: 로그인이 필요합니다!")
+                        ResponseDto.fail("AUTHENTICATION FAILED","인증실패: 로그인이 필요합니다!")
                 )
         );
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);


### PR DESCRIPTION
회원 로그인
* 로그인 시 토큰 발행 
* 로그인 시 비밀번호 일치하는 지 확인하는 로직 구현 

회원 정보 수정 
* form-data를 사용한 기능 구현
* 특정 column이 null 이어도 수정이 될 수 있게 구현 완료 
* S3에 기존에 이미지 삭제되는 로직 추가 
* AmazonS3Service 로직에서 유연하게 filePath를 설정 할 수 있도록 변경 